### PR TITLE
Fixed Broken "Find Out More" Links

### DIFF
--- a/templates/modular/latest_projects.html.twig
+++ b/templates/modular/latest_projects.html.twig
@@ -28,7 +28,7 @@
         <div class="desc text-left">{{ item.content }}</div>
 
         {% if item.header.link.url and item.header.link.title %}
-          <a class="btn btn-cta-secondary" href="{{ item.link.url }}"><i class="fa fa-thumbs-o-up"></i> {{ item.header.link.title }}</a>
+          <a class="btn btn-cta-secondary" href="{{ item.header.link.url }}"><i class="fa fa-thumbs-o-up"></i> {{ item.header.link.title }}</a>
         {% endif %}
       </div>
 
@@ -49,7 +49,7 @@
           <div>{{ item.content }}</div>
 
           {% if item.header.link.url and item.header.link.title %}
-            <p><a class="more-link" href="{{ project.header.link.url }}"><i class="fa fa-external-link"></i> {{ item.header.link.title }}</a></p>
+            <p><a class="more-link" href="{{ item.header.link.url }}"><i class="fa fa-external-link"></i> {{ item.header.link.title }}</a></p>
           {% endif %}
         </div>
       </div>


### PR DESCRIPTION
This enables the link you set in the page's YAML to propagate to the read more links. Otherwise, they go to the home page you're already at.